### PR TITLE
fix: remove UB in CWallmarksEngine

### DIFF
--- a/Sources/Runtime/xrRender/WallmarksEngine.cpp
+++ b/Sources/Runtime/xrRender/WallmarksEngine.cpp
@@ -279,10 +279,9 @@ void CWallmarksEngine::AddWallmark_internal(CDB::TRI* pTri, const fvec3* pVerts,
 		Fbox bb;
 		bb.invalidate();
 
-		FVF::LIT* I = &*W->verts.begin();
-		FVF::LIT* E = &*W->verts.end();
-		for (; I != E; I++)
-			bb.modify(I->p);
+		for (const auto& I : W->verts)
+			bb.modify(I.p);
+
 		bb.getsphere(W->bounds.P, W->bounds.R);
 	}
 

--- a/Sources/Runtime/xrRender/WallmarksEngine.cpp
+++ b/Sources/Runtime/xrRender/WallmarksEngine.cpp
@@ -128,13 +128,13 @@ void CWallmarksEngine::static_wm_render(CWallmarksEngine::static_wallmark* W, FV
 	int aC = iFloor(a * 255.f);
 	clamp(aC, 0, 255);
 	u32 C = color_rgba(128, 128, 128, aC);
-	FVF::LIT* S = &*W->verts.begin();
-	FVF::LIT* E = &*W->verts.end();
-	for (; S != E; S++, V++)
+
+	for (const auto& vert : W->verts)
 	{
-		V->p.set(S->p);
+		V->p.set(vert.p);
 		V->color = C;
-		V->t.set(S->t);
+		V->t.set(vert.t);
+		V++;
 	}
 }
 


### PR DESCRIPTION
* Dereference of `.end()` is UB. Triggers assert in MSVC Debug build.

Fixes #31 