### PR TITLE
SDL3 window mangement

### DIFF
--- a/Sources/Runtime/xrEngine/Engine.cpp
+++ b/Sources/Runtime/xrEngine/Engine.cpp
@@ -25,6 +25,7 @@
 #include "LevelLoadingScreen.h"
 #include "render.h"
 #include "xrBind_PSGP.h"
+#include "EngineQuit.hpp"
 #include "SDL3/SDL.h"
 //////////////////////////////////////////////////////////////////////////
 #define TRIVIAL_ENCRYPTOR_DECODER
@@ -484,7 +485,7 @@ void CEngine::ProcessEventLoop()
 	Events.AppStart.Process(rp_AppStart);
 	Engine.SetUnloaded();
 
-	while (true)
+	while (!g_QuitRequested)
 	{
 		if (!WindowManager.ProcessMessages())
 			break;

--- a/Sources/Runtime/xrEngine/Engine.cpp
+++ b/Sources/Runtime/xrEngine/Engine.cpp
@@ -161,6 +161,7 @@ CEngine::CEngine()
 	tune_pause = dummy;
 	tune_resume = dummy;
 	m_bLoaded = FALSE;
+	m_bUseSDL3 = false;
 }
 
 CEngine::~CEngine()
@@ -191,8 +192,15 @@ bool CEngine::Initialize()
 	// Инициализация ядра (xrCore)
 	Core.Initialize("X-Ray Engine", "xray_engine");
 
-	// Called after Core.Initialize() to ensure the SDL3 messages would end up in the .log files
-	InitSDL3();
+	m_bUseSDL3 = strstr(Core.Params, "-sdl3");
+
+	if (m_bUseSDL3)
+	{
+		Msg("~ SDL3 requested. Work In Progress.");
+
+		// Called after Core.Initialize() to ensure the SDL3 messages would end up in the .log files
+		InitSDL3();
+	}
 
 	// Инициализация настроек (Settings / INI)
 	{
@@ -565,7 +573,10 @@ void CEngine::Destroy()
 	Event._destroy();
 	XRC.r_clear_compact();
 
-	ShutdownSDL3();
+	if (m_bUseSDL3)
+	{
+		ShutdownSDL3();
+	}
 
 	Core.Destroy();
 }

--- a/Sources/Runtime/xrEngine/Engine.cpp
+++ b/Sources/Runtime/xrEngine/Engine.cpp
@@ -59,8 +59,87 @@ typedef void DUMMY_STUFF(const void*, const u32&, void*);
 XRCORE_API DUMMY_STUFF* g_temporary_stuff;
 //////////////////////////////////////////////////////////////////////////
 
+// Log callback to route SDL3 messages to console/logs
+static void LogCallbackSDL3(void* userdata, int category, SDL_LogPriority priority, const char* message)
+{
+	(void)userdata;
+
+	pcstr category_str = "unknown";
+	switch (category)
+	{
+	case SDL_LOG_CATEGORY_APPLICATION:
+		category_str = "app";
+		break;
+	case SDL_LOG_CATEGORY_ERROR:
+		category_str = "error";
+		break;
+	case SDL_LOG_CATEGORY_ASSERT:
+		category_str = "assert";
+		break;
+	case SDL_LOG_CATEGORY_SYSTEM:
+		category_str = "system";
+		break;
+	case SDL_LOG_CATEGORY_AUDIO:
+		category_str = "audio";
+		break;
+	case SDL_LOG_CATEGORY_VIDEO:
+		category_str = "video";
+		break;
+	case SDL_LOG_CATEGORY_RENDER:
+		category_str = "render";
+		break;
+	case SDL_LOG_CATEGORY_INPUT:
+		category_str = "input";
+		break;
+	case SDL_LOG_CATEGORY_TEST:
+		category_str = "test";
+		break;
+	case SDL_LOG_CATEGORY_GPU:
+		category_str = "gpu";
+		break;
+	}
+
+	char console_mark = '?';
+	pcstr priority_str = "unknown";
+	switch (priority)
+	{
+	case SDL_LOG_PRIORITY_TRACE:
+		priority_str = "trace";
+		console_mark = '%';
+		break;
+	case SDL_LOG_PRIORITY_VERBOSE:
+		priority_str = "verbose";
+		console_mark = '%';
+		break;
+	case SDL_LOG_PRIORITY_DEBUG:
+		priority_str = "debug";
+		console_mark = '#';
+		break;
+	case SDL_LOG_PRIORITY_INFO:
+		priority_str = "info";
+		console_mark = '*';
+		break;
+	case SDL_LOG_PRIORITY_WARN:
+		priority_str = "warn";
+		console_mark = '~';
+		break;
+	case SDL_LOG_PRIORITY_ERROR:
+		priority_str = "error";
+		console_mark = '!';
+		break;
+	case SDL_LOG_PRIORITY_CRITICAL:
+		priority_str = "critical";
+		console_mark = '$';
+		break;
+	}
+
+	Msg("%c [SDL3][%s][%s] %s", console_mark, category_str, priority_str, message);
+}
+
 static void InitSDL3()
 {
+	SDL_SetLogOutputFunction(LogCallbackSDL3, nullptr);
+
 	SDL_InitFlags sdl_flags = SDL_INIT_VIDEO;
 
 	R_ASSERT3(SDL_Init(sdl_flags), "Failed to initialize SDL3", SDL_GetError());
@@ -109,10 +188,11 @@ bool CEngine::Initialize()
 	// Build Info
 	InitializeGlobalBuildID();
 
-	InitSDL3();
-
 	// Инициализация ядра (xrCore)
 	Core.Initialize("X-Ray Engine", "xray_engine");
+
+	// Called after Core.Initialize() to ensure the SDL3 messages would end up in the .log files
+	InitSDL3();
 
 	// Инициализация настроек (Settings / INI)
 	{
@@ -485,9 +565,9 @@ void CEngine::Destroy()
 	Event._destroy();
 	XRC.r_clear_compact();
 
-	Core.Destroy();
-
 	ShutdownSDL3();
+
+	Core.Destroy();
 }
 
 void CEngine::Run()

--- a/Sources/Runtime/xrEngine/Engine.cpp
+++ b/Sources/Runtime/xrEngine/Engine.cpp
@@ -236,7 +236,7 @@ bool CEngine::Initialize()
 	Statistic->Initialize();
 
 	Logo->Hide();
-	WindowManager.Initialize();
+	WindowManager.Initialize(m_bUseSDL3);
 
 	{
 		BOOL bCaptureInput = !strstr(Core.Params, "-i");

--- a/Sources/Runtime/xrEngine/Engine.h
+++ b/Sources/Runtime/xrEngine/Engine.h
@@ -63,6 +63,8 @@ class ENGINE_API CEngine
 
 	bool m_bLoaded;
 
+	bool m_bUseSDL3;
+
 	xr_list<LOADING_EVENT> m_loading_events;
 
   public:

--- a/Sources/Runtime/xrEngine/EngineQuit.cpp
+++ b/Sources/Runtime/xrEngine/EngineQuit.cpp
@@ -1,0 +1,4 @@
+#include "stdafx.h"
+#include "EngineQuit.hpp"
+
+std::atomic<bool> g_QuitRequested{false};

--- a/Sources/Runtime/xrEngine/EngineQuit.hpp
+++ b/Sources/Runtime/xrEngine/EngineQuit.hpp
@@ -1,0 +1,4 @@
+#pragma once
+#include <atomic>
+
+extern std::atomic<bool> g_QuitRequested;

--- a/Sources/Runtime/xrEngine/GameStateManager.cpp
+++ b/Sources/Runtime/xrEngine/GameStateManager.cpp
@@ -14,6 +14,7 @@
 #include "Text_Console.h"
 #include <process.h>
 #include "LevelLoadingScreen.h"
+#include "EngineQuit.hpp"
 
 void CGameStateManager::Initialize()
 {
@@ -49,7 +50,7 @@ void CGameStateManager::OnEvent(EVENT E, u64 P1, u64 P2)
 
 	if (E == eQuit)
 	{
-		PostQuitMessage(0);
+		g_QuitRequested = true;
 	}
 	else if (E == eStart)
 	{

--- a/Sources/Runtime/xrEngine/R_Backend.cpp
+++ b/Sources/Runtime/xrEngine/R_Backend.cpp
@@ -130,24 +130,10 @@ void CRenderBackend::Create(HWND m_hWnd)
     wm.SetRefreshRate(refreshHz);
     wm.Apply();
 
-    SetWindowPos(m_hWnd, nullptr, 0, 0, width, height, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-    UpdateWindow(m_hWnd);
-
     RECT rcClient;
     GetClientRect(m_hWnd, &rcClient);
     LONG clientW = rcClient.right - rcClient.left;
     LONG clientH = rcClient.bottom - rcClient.top;
-
-    if (clientW != width || clientH != height)
-    {
-        Msg("! Window client size mismatch: expected %dx%d, got %dx%d. Forcing resize.", width, height, clientW, clientH);
-        SetWindowLongPtr(m_hWnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);
-        SetWindowPos(m_hWnd, HWND_TOP, 0, 0, width, height, SWP_NOMOVE | SWP_SHOWWINDOW);
-        UpdateWindow(m_hWnd);
-        GetClientRect(m_hWnd, &rcClient);
-        clientW = rcClient.right - rcClient.left;
-        clientH = rcClient.bottom - rcClient.top;
-    }
 
     xrRHI::RHIPresentationParams params;
     params.BackBufferWidth = clientW;
@@ -260,24 +246,11 @@ void CRenderBackend::Reset()
     wm.Apply();
 
     HWND hWnd = wm.GetHandle();
-    SetWindowPos(hWnd, nullptr, 0, 0, width, height, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-    UpdateWindow(hWnd);
 
     RECT rcClient;
     GetClientRect(hWnd, &rcClient);
     LONG clientW = rcClient.right - rcClient.left;
     LONG clientH = rcClient.bottom - rcClient.top;
-
-    if (clientW != width || clientH != height)
-    {
-        Msg("! Window client size mismatch: expected %dx%d, got %dx%d. Forcing resize.", width, height, clientW, clientH);
-        SetWindowLongPtr(hWnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);
-        SetWindowPos(hWnd, HWND_TOP, 0, 0, width, height, SWP_NOMOVE | SWP_SHOWWINDOW);
-        UpdateWindow(hWnd);
-        GetClientRect(hWnd, &rcClient);
-        clientW = rcClient.right - rcClient.left;
-        clientH = rcClient.bottom - rcClient.top;
-    }
 
     xrRHI::RHIPresentationParams params;
     params.BackBufferWidth = clientW;

--- a/Sources/Runtime/xrEngine/WindowManager.cpp
+++ b/Sources/Runtime/xrEngine/WindowManager.cpp
@@ -3,6 +3,7 @@
 #include "device.h"
 #include "resource.h"
 #include "xr_ioc_cmd.h"
+#include "SDL3/SDL.h"
 
 // -----------------------------------------------------------------------------------
 // Construction / Destruction
@@ -14,6 +15,9 @@ CWindowManager::CWindowManager()
     m_RefreshRate(0),
     m_PositionX(CW_USEDEFAULT), m_PositionY(CW_USEDEFAULT),
     m_bQuitRequested(false),
+    m_bUseSDL3(false),
+    m_pSdlWindow(nullptr),
+    m_WindowTitle("S.T.A.L.K.E.R.: Shadow Of Chernobyl"),
     m_bInitialized(false)
 {}
 
@@ -22,27 +26,25 @@ CWindowManager::~CWindowManager() {}
 // -----------------------------------------------------------------------------------
 // Public API
 // -----------------------------------------------------------------------------------
-void CWindowManager::Initialize()
+void CWindowManager::InitializeWin32()
 {
-    Msg("Initializing Window Manager...");
     m_hInstance = GetModuleHandle(nullptr);
-    RegisterWindowClass();
-    CreateGameWindow();
-    m_bInitialized = true;
+    RegisterWindowClassWin32();
+    CreateGameWindowWin32();
 }
 
-void CWindowManager::Apply()
+void CWindowManager::ApplyWin32()
 {
     if (!m_bInitialized)
     {
-        CreateGameWindow();
+        CreateGameWindowWin32();
         m_bInitialized = true;
         return;
     }
-    UpdateWindowAttributes();   // окно уже существует Ц мен€ем атрибуты без пересоздани€
+    UpdateWindowAttributesWin32();   // окно уже существует Ц мен€ем атрибуты без пересоздани€
 }
 
-void CWindowManager::Destroy()
+void CWindowManager::DestroyWin32()
 {
     if (m_hWnd)
     {
@@ -51,7 +53,7 @@ void CWindowManager::Destroy()
     }
 }
 
-bool CWindowManager::ProcessMessages()
+bool CWindowManager::ProcessMessagesWin32()
 {
     MSG msg;
     while (PeekMessage(&msg, nullptr, 0U, 0U, PM_REMOVE))
@@ -67,7 +69,7 @@ bool CWindowManager::ProcessMessages()
     return !m_bQuitRequested;
 }
 
-void CWindowManager::SetResolution(u32 w, u32 h)
+void CWindowManager::SetResolutionWin32(u32 w, u32 h)
 {
     m_width = w;
     m_height = h;
@@ -76,7 +78,7 @@ void CWindowManager::SetResolution(u32 w, u32 h)
     m_PositionY = CW_USEDEFAULT;
 }
 
-void CWindowManager::CenterWindow()
+void CWindowManager::CenterWindowWin32()
 {
     if (!m_hWnd || !m_bWindowed)
         return;
@@ -88,7 +90,7 @@ void CWindowManager::CenterWindow()
 
     HMONITOR hMon = MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST);
     int newX, newY;
-    ComputeCenteredPosition(hMon, winW, winH, newX, newY);
+    ComputeCenteredPositionWin32(hMon, winW, winH, newX, newY);
 
     m_PositionX = newX;
     m_PositionY = newY;
@@ -100,11 +102,11 @@ void CWindowManager::CenterWindow()
 // -----------------------------------------------------------------------------------
 // Private helpers
 // -----------------------------------------------------------------------------------
-void CWindowManager::RegisterWindowClass()
+void CWindowManager::RegisterWindowClassWin32()
 {
     WNDCLASS wndClass = {};
     wndClass.style = CS_OWNDC | CS_HREDRAW | CS_VREDRAW;
-    wndClass.lpfnWndProc = WndProc;
+    wndClass.lpfnWndProc = WndProcWin32;
     wndClass.hInstance = m_hInstance;
     wndClass.hIcon = LoadIcon(m_hInstance, MAKEINTRESOURCE(IDI_ICON1));
     wndClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
@@ -114,12 +116,11 @@ void CWindowManager::RegisterWindowClass()
     RegisterClass(&wndClass);
 }
 
-void CWindowManager::CreateGameWindow()
+void CWindowManager::CreateGameWindowWin32()
 {
     const char* wndclass = "_XRAY_";
-    const char* title = "S.T.A.L.K.E.R.: Shadow Of Chernobyl";
 
-    DWORD style = GetStyle();
+    DWORD style = GetStyleWin32();
     int winW = m_width, winH = m_height;   // дл€ borderless это и есть размер окна
 
     int x = CW_USEDEFAULT, y = CW_USEDEFAULT;
@@ -127,7 +128,7 @@ void CWindowManager::CreateGameWindow()
     {
         // ѕервое создание Ч центрируем по основному монитору
         HMONITOR hMon = MonitorFromPoint({ 0,0 }, MONITOR_DEFAULTTOPRIMARY);
-        ComputeCenteredPosition(hMon, winW, winH, x, y);
+        ComputeCenteredPositionWin32(hMon, winW, winH, x, y);
         m_PositionX = x;
         m_PositionY = y;
     }
@@ -139,7 +140,7 @@ void CWindowManager::CreateGameWindow()
 
     m_hWnd = CreateWindowEx(
         m_bWindowed ? 0 : WS_EX_TOPMOST,   // полноэкранный Ц всегда поверх
-        wndclass, title, style,
+        wndclass, m_WindowTitle, style,
         x, y, winW, winH,
         nullptr, nullptr, m_hInstance, nullptr);
 
@@ -164,12 +165,12 @@ void CWindowManager::CreateGameWindow()
         m_hWnd, m_width, m_height, m_bWindowed ? "yes" : "no");
 }
 
-void CWindowManager::UpdateWindowAttributes()
+void CWindowManager::UpdateWindowAttributesWin32()
 {
     if (!m_hWnd) return;
 
     // 1. ѕримен€ем стиль окна (без рамок) и расширенный стиль (TopMost дл€ fullscreen)
-    ApplyWindowStyle(m_bWindowed ? 0 : WS_EX_TOPMOST);
+    ApplyWindowStyleWin32(m_bWindowed ? 0 : WS_EX_TOPMOST);
 
     const int winW = m_width;
     const int winH = m_height;
@@ -179,7 +180,7 @@ void CWindowManager::UpdateWindowAttributes()
         // ќконный режим: всегда центрируем на текущем мониторе
         HMONITOR hMon = MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST);
         int centerX, centerY;
-        ComputeCenteredPosition(hMon, winW, winH, centerX, centerY);
+        ComputeCenteredPositionWin32(hMon, winW, winH, centerX, centerY);
 
         // ѕеремещаем окно в центр, не отбира€ фокус
         SetWindowPos(m_hWnd, nullptr, centerX, centerY, winW, winH,
@@ -205,7 +206,7 @@ void CWindowManager::UpdateWindowAttributes()
     m_height = rcClient.bottom - rcClient.top;
 }
 
-void CWindowManager::ComputeCenteredPosition(HMONITOR hMonitor, int winW, int winH, int& outX, int& outY)
+void CWindowManager::ComputeCenteredPositionWin32(HMONITOR hMonitor, int winW, int winH, int& outX, int& outY)
 {
     MONITORINFO mi = { sizeof(mi) };
     GetMonitorInfo(hMonitor, &mi);
@@ -215,7 +216,7 @@ void CWindowManager::ComputeCenteredPosition(HMONITOR hMonitor, int winW, int wi
     outY = work.top + (work.bottom - work.top - winH) / 2;
 }
 
-void CWindowManager::SaveWindowPosition()
+void CWindowManager::SaveWindowPositionWin32()
 {
     if (!m_hWnd)
         return;
@@ -234,9 +235,9 @@ void CWindowManager::SaveWindowPosition()
     }
 }
 
-void CWindowManager::ApplyWindowStyle(DWORD exStyle)
+void CWindowManager::ApplyWindowStyleWin32(DWORD exStyle)
 {
-    SetWindowLongPtr(m_hWnd, GWL_STYLE, GetStyle());
+    SetWindowLongPtr(m_hWnd, GWL_STYLE, GetStyleWin32());
     SetWindowLongPtr(m_hWnd, GWL_EXSTYLE, exStyle);
 
     // «аставл€ем систему пересчитать неклиентскую область (она исчезнет/по€витс€)
@@ -247,7 +248,7 @@ void CWindowManager::ApplyWindowStyle(DWORD exStyle)
 // -----------------------------------------------------------------------------------
 // Static window procedure
 // -----------------------------------------------------------------------------------
-LRESULT CALLBACK CWindowManager::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK CWindowManager::WndProcWin32(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
@@ -287,4 +288,182 @@ LRESULT CALLBACK CWindowManager::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LP
     }
     }
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+
+void CWindowManager::Initialize(bool use_sdl3)
+{
+    Msg("Initializing Window Manager...");
+
+    m_bUseSDL3 = use_sdl3;
+
+    if (m_bUseSDL3)
+        InitializeSDL3();
+    else
+        InitializeWin32();
+
+    m_bInitialized = true;
+}
+
+void CWindowManager::Destroy()
+{
+    if (m_bUseSDL3)
+        DestroySDL3();
+    else
+        DestroyWin32();
+}
+
+void CWindowManager::Apply()
+{
+    if (m_bUseSDL3)
+        ApplySDL3();
+    else
+        ApplyWin32();
+}
+
+bool CWindowManager::ProcessMessages()
+{
+    if (m_bUseSDL3)
+        return ProcessMessagesSDL3();
+    else
+        return ProcessMessagesWin32();
+}
+
+void CWindowManager::SetResolution(u32 w, u32 h)
+{
+    if (m_bUseSDL3)
+        SetResolutionSDL3(w, h);
+    else
+        SetResolutionWin32(w, h);
+}
+
+void CWindowManager::CenterWindow()
+{
+    if (m_bUseSDL3)
+        CenterWindowSDL3();
+    else
+        CenterWindowWin32();
+}
+
+void CWindowManager::InitializeSDL3()
+{
+    SDL_Log("Creating game window");
+
+    SDL_WindowFlags sdl_window_flags = SDL_WINDOW_MOUSE_GRABBED;
+
+    m_pSdlWindow = SDL_CreateWindow(
+        m_WindowTitle,
+        m_width, m_height,
+        sdl_window_flags
+    );
+
+    R_ASSERT3(m_pSdlWindow, "Failed to create SDL3 window", SDL_GetError());
+
+    SDL_Log("Getting HWND handle from game window");
+
+    SDL_PropertiesID window_props = SDL_GetWindowProperties(m_pSdlWindow);
+
+    void* sdl_hwnd = SDL_GetPointerProperty(window_props, SDL_PROP_WINDOW_WIN32_HWND_POINTER, nullptr);
+
+    R_ASSERT3(sdl_hwnd, "Failed to get HWND from SDL3 window", SDL_GetError());
+
+    m_hWnd = (HWND)sdl_hwnd;
+
+    SDL_Log("Created SDL3 window: window 0x%p, hwnd 0x%p", m_pSdlWindow, m_hWnd);
+}
+
+void CWindowManager::DestroySDL3()
+{
+    if (m_hWnd)
+    {
+        m_hWnd = nullptr;
+    }
+
+    if (m_pSdlWindow)
+    {
+        SDL_DestroyWindow(m_pSdlWindow);
+        m_pSdlWindow = nullptr;
+    }
+}
+
+void CWindowManager::ApplySDL3()
+{
+    if (!m_pSdlWindow)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "%s: the m_pSdlWindow is null!", __FUNCTION__);
+        return;
+    }
+
+    SDL_SetWindowSize(m_pSdlWindow, m_width, m_height);
+    SDL_SetWindowFullscreen(m_pSdlWindow, !m_bWindowed);
+
+    CenterWindowSDL3();
+
+    R_ASSERT3(SDL_SyncWindow(m_pSdlWindow), "SDL_SyncWindow timeout", SDL_GetError());
+
+    int w{};
+    int h{};
+    R_ASSERT3(SDL_GetWindowSize(m_pSdlWindow, &w, &h), "SDL_GetWindowSize failed", SDL_GetError());
+    m_width = w;
+    m_height = h;
+}
+
+bool CWindowManager::ProcessMessagesSDL3()
+{
+    static bool minimized = false;
+    static bool focused = false;
+
+    SDL_Event event;
+    while (SDL_PollEvent(&event))
+    {
+        if (SDL_GetLogPriority(SDL_LOG_CATEGORY_APPLICATION) <= SDL_LOG_PRIORITY_VERBOSE)
+        {
+            string512 event_desc;
+
+            SDL_GetEventDescription(&event, event_desc, sizeof(event_desc));
+
+            SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "Received event %s", event_desc);
+        }
+
+        switch (event.type)
+        {
+        case SDL_EVENT_QUIT:
+            m_bQuitRequested = true;
+            break;
+        case SDL_EVENT_WINDOW_MINIMIZED:
+            minimized = true;
+            break;
+        case SDL_EVENT_WINDOW_RESTORED:
+            minimized = false;
+            break;
+        case SDL_EVENT_WINDOW_FOCUS_GAINED:
+            focused = true;
+            break;
+        case SDL_EVENT_WINDOW_FOCUS_LOST:
+            focused = false;
+            break;
+        }
+    }
+
+    bool device_should_be_active = !minimized && focused;
+
+    Device.SetActivate(device_should_be_active);
+
+    return !m_bQuitRequested;
+}
+
+void CWindowManager::SetResolutionSDL3(u32 w, u32 h)
+{
+    m_width = w;
+    m_height = h;
+}
+
+void CWindowManager::CenterWindowSDL3()
+{
+    if (!m_pSdlWindow)
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "%s: the m_pSdlWindow is null!", __FUNCTION__);
+        return;
+    }
+
+    SDL_SetWindowPosition(m_pSdlWindow, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }

--- a/Sources/Runtime/xrEngine/WindowManager.cpp
+++ b/Sources/Runtime/xrEngine/WindowManager.cpp
@@ -252,7 +252,13 @@ LRESULT CALLBACK CWindowManager::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LP
     switch (uMsg)
     {
     case WM_ACTIVATE:
-        Device.OnWM_Activate(wParam, lParam);
+        {
+            u16 fActive = LOWORD(wParam);
+            BOOL fMinimized = (BOOL)HIWORD(wParam);
+            BOOL bActive = ((fActive != WA_INACTIVE) && (!fMinimized)) ? TRUE : FALSE;
+
+            Device.SetActivate(bActive);
+        }
         break;
     case WM_SETCURSOR:
         return 1;

--- a/Sources/Runtime/xrEngine/WindowManager.h
+++ b/Sources/Runtime/xrEngine/WindowManager.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "stdafx.h"
+#include "SDL3/SDL.h"
 
 class ENGINE_API CWindowManager
 {
@@ -7,7 +8,7 @@ public:
     CWindowManager();
     ~CWindowManager();
 
-    void Initialize();
+    void Initialize(bool use_sdl3);
     void Destroy();
     void Apply();               // применить накопленные параметры
     void Reset() { Apply(); }   // совместимость
@@ -42,21 +43,39 @@ private:
     int       m_PositionY;
     bool      m_bQuitRequested;
     bool      m_bInitialized;
+    pcstr     m_WindowTitle;
 
     // Стиль окна (borderless)
-    DWORD GetStyle() const { return WS_POPUP | WS_VISIBLE; }
+    DWORD GetStyleWin32() const { return WS_POPUP | WS_VISIBLE; }
 
     // Внутренние хелперы
-    void RegisterWindowClass();
-    void CreateGameWindow();
-    void UpdateWindowAttributes();
+    void RegisterWindowClassWin32();
+    void CreateGameWindowWin32();
+    void UpdateWindowAttributesWin32();
 
     // Центрирование: вычисляет координаты относительно рабочей области монитора
-    void ComputeCenteredPosition(HMONITOR hMonitor, int winW, int winH, int& outX, int& outY);
+    void ComputeCenteredPositionWin32(HMONITOR hMonitor, int winW, int winH, int& outX, int& outY);
     // Сохраняет текущую позицию окна (только если окно существует и не полноэкранное)
-    void SaveWindowPosition();
+    void SaveWindowPositionWin32();
     // Устанавливает стиль и расширенный стиль, затем заставляет систему пересчитать неклиентскую область
-    void ApplyWindowStyle(DWORD exStyle = 0);
+    void ApplyWindowStyleWin32(DWORD exStyle = 0);
 
-    static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    static LRESULT CALLBACK WndProcWin32(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+    bool m_bUseSDL3;
+
+    SDL_Window* m_pSdlWindow;
+
+    void InitializeWin32();
+    void InitializeSDL3();
+    void DestroyWin32();
+    void DestroySDL3();
+    void ApplyWin32();
+    void ApplySDL3();
+    bool ProcessMessagesWin32();
+    bool ProcessMessagesSDL3();
+    void SetResolutionWin32(u32 w, u32 h);
+    void SetResolutionSDL3(u32 w, u32 h);
+    void CenterWindowWin32();
+    void CenterWindowSDL3();
 };

--- a/Sources/Runtime/xrEngine/device.cpp
+++ b/Sources/Runtime/xrEngine/device.cpp
@@ -147,12 +147,8 @@ BOOL CRenderDevice::Paused()
     return g_pauseMngr.Paused();
 }
 
-void CRenderDevice::OnWM_Activate(WPARAM wParam, LPARAM lParam)
+void CRenderDevice::SetActivate(bool bActive)
 {
-    u16 fActive = LOWORD(wParam);
-    BOOL fMinimized = (BOOL)HIWORD(wParam);
-    BOOL bActive = ((fActive != WA_INACTIVE) && (!fMinimized)) ? TRUE : FALSE;
-
     if (bActive != Device.b_is_Active)
     {
         Device.b_is_Active = bActive;

--- a/Sources/Runtime/xrEngine/device.h
+++ b/Sources/Runtime/xrEngine/device.h
@@ -31,8 +31,8 @@ class ENGINE_API CRenderDevice
 	u32 dwWidth, dwHeight;
 	float fWidth_2, fHeight_2;
 	BOOL b_is_Ready;
-	BOOL b_is_Active;
-	void OnWM_Activate(WPARAM wParam, LPARAM lParam);
+	bool b_is_Active;
+	void SetActivate(bool bActive);
 
 	fvec2 GetScreenResolution()
 	{

--- a/Sources/Runtime/xrEngine/xrEngine.vcxproj
+++ b/Sources/Runtime/xrEngine/xrEngine.vcxproj
@@ -702,6 +702,7 @@
     <ClInclude Include="CameraDefs.h" />
     <ClInclude Include="CameraManager.h" />
     <ClInclude Include="CPhotoMode.h" />
+    <ClInclude Include="EngineQuit.hpp" />
     <ClInclude Include="RenderView.h" />
     <ClInclude Include="CustomHUD.h" />
     <ClInclude Include="D3DUtils.h" />
@@ -841,6 +842,7 @@
     <ClCompile Include="CameraBase.cpp" />
     <ClCompile Include="CameraManager.cpp" />
     <ClCompile Include="CPhotoMode.cpp" />
+    <ClCompile Include="EngineQuit.cpp" />
     <ClCompile Include="RenderView.cpp" />
     <ClCompile Include="CustomHUD.cpp" />
     <ClCompile Include="D3DUtils.cpp" />

--- a/Sources/Runtime/xrEngine/xrEngine.vcxproj.filters
+++ b/Sources/Runtime/xrEngine/xrEngine.vcxproj.filters
@@ -630,6 +630,9 @@
     <ClInclude Include="R_Backend_tree.h">
       <Filter>Render\Execution &amp; 3D\Backend</Filter>
     </ClInclude>
+    <ClInclude Include="EngineQuit.hpp">
+      <Filter>Engine\Core</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="IInputReceiver.cpp">
@@ -1048,6 +1051,9 @@
     </ClCompile>
     <ClCompile Include="R_Backend_tree.cpp">
       <Filter>Render\Execution &amp; 3D\Backend</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineQuit.cpp">
+      <Filter>Engine\Core</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Sources/Runtime/xrEngine/xr_object_list.cpp
+++ b/Sources/Runtime/xrEngine/xr_object_list.cpp
@@ -184,9 +184,12 @@ void CObjectList::Update(bool bForce)
 					objects_dup_memsz += 32;
 				objects_dup = (CObject**)xr_realloc(objects_dup, objects_dup_memsz * sizeof(CObject*));
 			}
-			CopyMemory(objects_dup, &*workload->begin(), objects_count * sizeof(CObject*));
-			for (u32 O = 0; O < objects_count; O++)
-				SingleUpdate(objects_dup[O]);
+			if (objects_count > 0)
+			{
+				CopyMemory(objects_dup, workload->data(), objects_count * sizeof(CObject*));
+				for (u32 O = 0; O < objects_count; O++)
+					SingleUpdate(objects_dup[O]);
+			}
 
 			Engine.Statistic->UpdateClient.End();
 		}


### PR DESCRIPTION
Initial implementation of SDL3 windowing. Uses `-sdl3` flag to switch between Win32 API and SDL3 API.

Important differences for now:
* Windowed mode is not borderless.
* Fullscreen uses the screen resolution instead of `vid_mode` setting.